### PR TITLE
Corrected the formatting of the product link

### DIFF
--- a/src/lamdas/campaign-create/campaign_create.py
+++ b/src/lamdas/campaign-create/campaign_create.py
@@ -11,7 +11,7 @@ def lambda_handler(event, context):
     segment_id = event["SegmentId"]
     product_name = event["product_name"]
     product_link = event["product_link"]
-    formatted_prod_link = (""" + {} + """).format(product_link)
+    formatted_prod_link = ('"' + {} + '"').format(product_link)
     from_email = os.environ.get("FROM_ADDRESS")
     campaign_name = "campaign" + "_" + interest + "_" + product_name
     appid = os.environ.get("PINPOINT_PROJECT_ID")


### PR DESCRIPTION
*Description of changes:*

Before fix, the formatted link output contained " + " which broke the hyperlink when clicked on the email. e.g. 
+ https://aws.amazon.com +

I have changed """ to '"' so the formatted link is now "https://aws.amazon.com"

The reason of the formatted link is so you can incorporate it in the HTML body easier by entering 
e.g. href = """ + formatted_product_link +""" 
